### PR TITLE
v0.6.0: Twitter Thread Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@
 ## 0.6.0: Twitter Thread Support
 
 * Added `--depth` and `-d` for archiving threads.
-* Added `TwitterPageInterface` used for representing a page in Twitter.
+* Added `TwitterPage` used for representing a page in Twitter.
 * Added `TwitterBio` which is used for fetching and obtaining bio pages.
-* Added `TweetFetcher` which attempts to fetch all available Tweets on a page.
+* Added `TwitterThread` which represents a tweet thread page.
+* Added `TweetExtractor` which attempts to fetch all available Tweets on a page.
 * Added `Scroller` which abstracts away scrolling metrics.
+* Added thread expansion functions: `hit_more_replies()` and `get_recommend_tweets_height()`.
 * Changed random messages from ChromeDriver, makes logs cleaner.
 * Fixed potential for some posts to be skipped on ad removal.
 * Fixed logger not outputting any info.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@
 
 # Changes
 
-## vNEXT
+## 0.6.0: Twitter Thread Support
 
+* Added `--depth` and `-d` for archiving threads.
 * Added `TwitterPageInterface` used for representing a page in Twitter.
 * Added `TwitterBio` which is used for fetching and obtaining bio pages.
 * Added `TweetFetcher` which attempts to fetch all available Tweets on a page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@
 ## 0.6.0: Twitter Thread Support
 
 * Added `--depth` and `-d` for archiving threads.
-* Added `TwitterPage` used for representing a page in Twitter.
-* Added `TwitterBio` which is used for fetching and obtaining bio pages.
-* Added `TwitterThread` which represents a tweet thread page.
+* Added `pages.py` which abstracts away a page on Twitter. Useful for multi-threading.
+    * Added `TwitterPage` used for representing a page in Twitter.
+    * Added `TwitterBio` which is used for fetching and obtaining bio pages.
+    * Added `TwitterThread` which represents a tweet thread page.
 * Added `TweetExtractor` which attempts to fetch all available Tweets on a page.
 * Added `Scroller` which abstracts away scrolling metrics.
 * Added thread expansion functions: `hit_more_replies()` and `get_recommend_tweets_height()`.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ This script is purely for the purposes of archival use only.
 
 * Stores metadata in json format for each specified twitter profile.
 * Neatly organizes tweets by user and takes a snapshot of each tweet.
+* Auto snapshots thread replies and reponses by depth relative to original tweet.
 * Marks potential tweets that are self-retweeted.
-* Removes Tweet Ads.
 * Allows for manual login (use at own risk.)
+* Removes Tweet Ads.
 
 ## Usage
 
@@ -32,6 +33,9 @@ python -m pip install -r requirements.txt
 # Take a snapshot from a given profile URL.
 python bin/watcher.py --url www.twitter.com/<profile>
 
+# Take a snapshot of profile tweets and their replies
+python bin/watcher.py --url www.twitter.com/<profile> -d 2
+
 # For more help use:
 python bin/watcher.py --help
 ```
@@ -40,21 +44,26 @@ Tested on Python 3.10.
 
 ### Output
 
-Birdwatch generates the following in the snapshots folder:
+TBwatch generates the following in the snapshots folder (assuming `--depth 2`):
 
 ```
 └───snapshots
     └───<user_id>           # Username
         │   metadata.json   # profile metadata
         │   profile.png     # snapshot of profile page
+        │   tweets.json     # text format of all tweets on profile page
         │
-        └───tweets
-                0.png       # snapshot of latest tweet
-                1.png
-                ...
-                9.png
-                tweets.json # Metadata of each screen-capped tweet.
+        └───<prof_tweet_id_0>
+            │   <prof_tweet_id_0>.png  # Snapshot
+            │   tweets.json            # Responses to <prof_tweet_id_0>
+            │
+            ├───<response_tweet_id_0>
+            │       <response_tweet_id_0>.png # Snapshot
+            │
+            └───<response_tweet_id_1>
+                    <response_tweet_id_1>.png # Snapshot
 ```
+
 
 ### Self Boosted Tweet Detection
 
@@ -103,6 +112,7 @@ You can rename as json or specify via input flags to parse the file. `window.* =
 ]
 ```
 
+`id` is the index assigned by Twitter.
 Invalid string entries will be marked as "NULL".
 
 ###  metadata.json
@@ -121,7 +131,6 @@ Invalid string entries will be marked as "NULL".
 ```
 
 Invalid string entries will be marked as "NULL".
-
 
 ## Troubleshoot
 

--- a/bin/watcher.py
+++ b/bin/watcher.py
@@ -72,6 +72,8 @@ def main():
         "number_posts_to_cap": args.posts
     }
 
+    args.output_fpath = args.output_fpath.strip()
+
     if args.debug:
         logger.setLevel(logger.DEBUG)
         logger.debug("Debug mode set.")

--- a/bin/watcher.py
+++ b/bin/watcher.py
@@ -18,7 +18,7 @@ sys.path.append(SRC_ROOT)
 import tb_watcher.swag as swag
 
 from tb_watcher.core import fetch_html
-from tb_watcher.logger import logger 
+from tb_watcher.logger import logger
 from tb_watcher.driver_utils import create_chrome_driver
 from tb_watcher.math_utils import calc_average_percentile, window_average, constant
 
@@ -36,6 +36,11 @@ def parse_args():
     runtime_group.add_argument("--posts", "-p", help="Max number of posts to screenshot.", default=20, type=int)
     runtime_group.add_argument("--bio-only", "-b", help="Only store bio, no snapshots of tweets.", action="store_true")
     runtime_group.add_argument("--debug", help="Print debug output.", action="store_true")
+    runtime_group.add_argument("--depth", "-d", default=1, type=int, help=("How deep to follow threads on Twitter."
+                                                                           "1 means only main threads on profile."
+                                                                           "2 means threads including responses on each tweet on profile."
+                                                                           "3 means threads of threads. So-on and so-forth."
+                                                                           "Note that duplicates will occur for >= 3."))
 
     verification_group = parser.add_argument_group("verification")
     verification_group.add_argument("--login", help="Prompt user login to remove limits / default filters. USE AT OWN RISK.", action="store_true")
@@ -69,8 +74,11 @@ def main():
         "force": args.force,
         "bio_only": args.bio_only,
         "load_times": args.scroll_load_time,
-        "number_posts_to_cap": args.posts
+        "number_posts_to_cap": args.posts,
+        "fetch_threads": args.depth
     }
+
+    assert args.depth >= 1, "You have to have atleast 1 depth in thread archiving."
 
     args.output_fpath = args.output_fpath.strip()
 
@@ -110,7 +118,7 @@ def main():
 
             # Remove the first line metadata
             data = json.loads(txt)
-    
+
         for d in data:
             account = d["following"]
             url = account["userLink"]

--- a/bin/watcher.py
+++ b/bin/watcher.py
@@ -95,6 +95,7 @@ def main():
 
     data = []
     if args.url:
+        logger.info("Watching: {}".format(args.url))
         fetch_html(driver, args.url, fpath=args.output_fpath, **extra_args)
     else:
         weird_opening = "window\..* = (\[[\S\s]*)"
@@ -110,9 +111,11 @@ def main():
     
         for d in data:
             account = d["following"]
-            fetch_html(driver, account["userLink"], fpath=args.output_fpath, **extra_args)
+            url = account["userLink"]
+            logger.info("Watching: {}".format(url))
+            fetch_html(driver, url, fpath=args.output_fpath, **extra_args)
 
-    logger.info("ALL SCRAPING COMPLETED!")
+    logger.info("ALL SNAPSHOTS COMPLETED!")
 
 if __name__ == "__main__":
     main()

--- a/src/tb_watcher/core.py
+++ b/src/tb_watcher/core.py
@@ -9,7 +9,6 @@ import json
 import shutil
 import time
 
-from abc import ABC, abstractmethod
 from typing import Callable, List
 from dataclasses import asdict
 
@@ -27,23 +26,11 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 DEF_NUM_TWEETS = 20
 
-class TwitterPageInterface(ABC):
+class TwitterPage:
     """Interface for a page on Twitter.
     Each page can allow for a driveer to optimize multi-threading.
     """
-    @abstractmethod
-    def get_driver(self) -> webdriver:
-        """
-        Returns the driver for a given page.
-        """
-
-class TwitterBio(TwitterPageInterface):
-    """
-    Class encapsulating a twitter bio page.
-    Owns an instance of driver for capturing your driving needs.
-    """
     def __init__(self, url: str, existing_driver: webdriver = None):
-        # Must be fetched or deserialized.
         self.metadata = None
 
         if existing_driver:
@@ -53,8 +40,21 @@ class TwitterBio(TwitterPageInterface):
         self.url = url
 
     def get_driver(self) -> webdriver:
+        """
+        Returns the driver for a given page.
+        """
         return self.driver
 
+class TwitterThread(TwitterPage):
+    """
+    Class encapsulating a twitter thread page.
+    """
+
+
+class TwitterBio(TwitterPage):
+    """
+    Class encapsulating a twitter bio page.
+    """
     def fetch_bio_data(self) -> BioMetadata:
         self.driver.get(self.url)
 
@@ -86,7 +86,6 @@ class TwitterBio(TwitterPageInterface):
 
         # Save metadata as local value.
         self.metadata = BioMetadata(**metadata)
-    
         return self.metadata
 
     def fetch_tweets(

--- a/src/tb_watcher/core.py
+++ b/src/tb_watcher/core.py
@@ -3,10 +3,6 @@ Houses the main logic for fetching data and interfacing with Selenium.
 By: ProgrammingIncluded
 """
 # std
-import os
-import json
-import shutil
-
 from typing import Callable
 
 # bluebird watcher
@@ -32,7 +28,7 @@ def fetch_html(
     # Many thanks to: https://www.scrapingbee.com/blog/web-scraping-twitter/
     # for the inspiration.
     # Major adjustments to make UX a lot smoother.
-    twitter_bio = TwitterBio(fpath, url, existing_driver=driver)
+    twitter_bio = TwitterBio(fpath, url, auto_fetch_threads=True, existing_driver=driver)
     twitter_bio.fetch_metadata()
     if not twitter_bio.write_json(force=force):
         return
@@ -43,5 +39,5 @@ def fetch_html(
     twitter_bio.fetch_tweets(
         number_posts_to_cap,
         load_times,
-        offset_func
+        offset_func,
     )

--- a/src/tb_watcher/core.py
+++ b/src/tb_watcher/core.py
@@ -20,15 +20,14 @@ def fetch_html(
     fpath: str,
     load_times: float,
     offset_func: Callable,
+    fetch_threads: int,
     force: bool = False,
     number_posts_to_cap: int = DEF_NUM_TWEETS,
     bio_only: bool = False):
     """Primary driver of the program."""
 
-    # Many thanks to: https://www.scrapingbee.com/blog/web-scraping-twitter/
-    # for the inspiration.
-    # Major adjustments to make UX a lot smoother.
-    twitter_bio = TwitterBio(fpath, url, auto_fetch_threads=True, existing_driver=driver)
+    # We add one to the fetch_threads as we need to include the thread id themselves.
+    twitter_bio = TwitterBio(fpath, url, fetch_threads=fetch_threads + 1, existing_driver=driver)
     twitter_bio.fetch_metadata()
     if not twitter_bio.write_json(force=force):
         return

--- a/src/tb_watcher/core.py
+++ b/src/tb_watcher/core.py
@@ -4,138 +4,19 @@ By: ProgrammingIncluded
 """
 # std
 import os
-import random
 import json
 import shutil
-import time
 
-from typing import Callable, List
-from dataclasses import asdict
+from typing import Callable
 
 # bluebird watcher
-from tb_watcher.driver_utils import (BioMetadata, MaxCapturesReached, Scroller, TweetExtractor, Tweet,
-                                     ensures_or, remove_elements, create_chrome_driver)
 from tb_watcher.logger import logger
+from tb_watcher.pages import TwitterBio
 
 # selenium
-import selenium
 from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
 
 DEF_NUM_TWEETS = 20
-
-class TwitterPage:
-    """Interface for a page on Twitter.
-    Each page can allow for a driveer to optimize multi-threading.
-    """
-    def __init__(self, url: str, existing_driver: webdriver = None):
-        self.metadata = None
-
-        if existing_driver:
-            self.driver = existing_driver
-        else:
-            self.driver = create_chrome_driver()
-        self.url = url
-
-    def get_driver(self) -> webdriver:
-        """
-        Returns the driver for a given page.
-        """
-        return self.driver
-
-class TwitterThread(TwitterPage):
-    """
-    Class encapsulating a twitter thread page.
-    """
-
-
-class TwitterBio(TwitterPage):
-    """
-    Class encapsulating a twitter bio page.
-    """
-    def fetch_bio_data(self) -> BioMetadata:
-        self.driver.get(self.url)
-
-        state = ""
-        while state != "complete":
-            time.sleep(random.uniform(3, 5))
-            state = self.driver.execute_script("return document.readyState")
-    
-        WebDriverWait(self.driver, 30).until(EC.presence_of_element_located(
-            (By.CSS_SELECTOR, '[data-testid="tweet"]')))
-    
-        # Remove initial popups.
-        remove_elements(self.driver, ["sheetDialog", "confirmationSheetDialog", "mask"])
-    
-        # delete bottom element
-        remove_elements(self.driver, ["BottomBar"])
-    
-        metadata = {}
-        metadata["bio"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'div[data-testid="UserDescription"]').text)
-        metadata["name"], metadata["username"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'div[data-testid="UserName"]').text.split('\n'), ("NULL", "NULL"))
-        metadata["location"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'span[data-testid="UserLocation"]').text)
-        metadata["website"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'a[data-testid="UserUrl"]').text)
-        metadata["join_date"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'span[data-testid="UserJoinDate"]').text)
-        metadata["following"] = ensures_or(lambda: self.driver.find_element(By.XPATH, "//span[contains(text(), 'Following')]/ancestor::a/span").text) 
-        metadata["followers"] = ensures_or(lambda: self.driver.find_element(By.XPATH, "//span[contains(text(), 'Followers')]/ancestor::a/span").text)
-    
-        if metadata.get("username", "NULL") == "NULL":
-            raise RuntimeError("Fatal error, unable to resolve username {}".format(metadata))
-
-        # Save metadata as local value.
-        self.metadata = BioMetadata(**metadata)
-        return self.metadata
-
-    def fetch_tweets(
-        self,
-        number_posts_to_cap: int,
-        tweets_path: str,
-        load_time: int,
-        offset_func: Callable
-    ) -> List[Tweet]:
-        id_tracker = 0
-        last_id = id_tracker
-        last_id_count = 0
-
-        extractor = TweetExtractor(tweets_path, max_captures=number_posts_to_cap)
-
-        # Wrap the offset function with extract height context.
-        offset_func = extractor.create_offset_function(offset_func)
-        try:
-            time.sleep(random.uniform(load_time, load_time + 2))
-            for _ in Scroller(self.driver, offset_func, load_time):
-                if id_tracker >= number_posts_to_cap - 1:
-                    break
-                elif last_id_count > 5:
-                    logger.debug("No more data to load?")
-                    break
-
-                # Just in case we keep hitting the same id.
-                if last_id == id_tracker:
-                    last_id_count += 1
-                else:
-                    last_id = id_tracker
-                    last_id_count = 0
-
-                # Capture the tweets and generates files for them
-                extractor.capture_all_available_tweets(self.driver)
-        except selenium.common.exceptions.StaleElementReferenceException as e:
-            logger.warning("Tweet limit reached, for {} unable to fetch more data. Authentication is required.".format(self.metadata.username))
-            logger.warning("Or you can try to bump loading times.")
-            raise e
-        except MaxCapturesReached as e:
-            pass
-        except Exception as e:
-            raise e
-        finally:
-            # Dump all metadata
-            with open(os.path.join(tweets_path, "tweets.json"), "w", encoding="utf-8") as f:
-                json.dump(extractor.get_tweets_as_dict(), f, ensure_ascii=False)
-
-    def get_bio_as_dict(self) -> dict:
-        return asdict(self.metadata)
 
 def fetch_html(
     driver: webdriver,
@@ -151,40 +32,16 @@ def fetch_html(
     # Many thanks to: https://www.scrapingbee.com/blog/web-scraping-twitter/
     # for the inspiration.
     # Major adjustments to make UX a lot smoother.
-    twitter_bio = TwitterBio(url, existing_driver=driver)
-    b_meta = twitter_bio.fetch_bio_data()
-
-    username = b_meta.username
-    assert b_meta.username[0] == "@"
-    username = username[1:]
-
-    fpath = os.path.join(fpath, username) 
-    if not force and os.path.exists(fpath):
-        logger.info("Folder already exists, skipping: {}".format(fpath))
+    twitter_bio = TwitterBio(fpath, url, existing_driver=driver)
+    twitter_bio.fetch_metadata()
+    if not twitter_bio.write_json(force=force):
         return
-    elif force and os.path.exists(fpath):
-        shutil.rmtree(fpath)
-
-    os.makedirs(fpath)
-
-    # Force utf-8
-    # Save a copy of the metadata
-    with open(os.path.join(fpath, "metadata.json"), "w", encoding="utf-8") as f:
-        json.dump(twitter_bio.get_bio_as_dict(), f, ensure_ascii=False)
-
-    # Save a screen shot of the bio
-    driver.save_screenshot(os.path.join(fpath, "profile.png"))
-
-    if bio_only:
+    elif bio_only:
         return
 
     # Create tweets folder
-    tweets_path = os.path.join(fpath, "tweets")
-    os.makedirs(tweets_path)
-
     twitter_bio.fetch_tweets(
         number_posts_to_cap,
-        tweets_path,
         load_times,
         offset_func
     )

--- a/src/tb_watcher/driver_utils.py
+++ b/src/tb_watcher/driver_utils.py
@@ -262,8 +262,8 @@ class TweetExtractor:
                     driver.execute_script("window.scrollTo(0, window.pageYOffset - 50);")
 
                     height = float(driver.execute_script("return window.scrollTop || window.pageYOffset;"))
-                    print("HEIGHT: {}".format(height))
-                    print("RECOMMEND: {}".format(self.recommended_tweets_height))
+                    logger.debug("HEIGHT: {}".format(height))
+                    logger.debug("RECOMMEND HEIGHT: {}".format(self.recommended_tweets_height))
                     # Verify that we are not in the recommended tweets section, if so, fail.
                     if self.recommended_tweets_height and height >= self.recommended_tweets_height - 10:
                         logger.debug("Hit recommended tweets section! Skipping.")
@@ -279,7 +279,6 @@ class TweetExtractor:
                 full_dtm = self.get_tweet(tweet, driver, fetch_threads, load_time, offset_func)
                 # We've seen this post before or is invalid tweet.
                 if full_dtm is None or full_dtm in self.tweets_tracker:
-                    print("NANI")
                     continue
 
                 # Create a tweet's folder
@@ -287,7 +286,6 @@ class TweetExtractor:
                 self.tweets_tracker.add(full_dtm)
 
                 if self.max_captures and self.counter > self.max_captures:
-                    print("CAPS")
                     exit_loop = True
                     break
 

--- a/src/tb_watcher/pages.py
+++ b/src/tb_watcher/pages.py
@@ -81,7 +81,6 @@ class TwitterPage:
         try:
             time.sleep(random.uniform(load_time, load_time + 2))
             for _ in Scroller(self.driver, extractor.create_offset_function(offset_func), load_time):
-                print("SCROLL")
                 if last_id_count > 5:
                     logger.debug("No more data to load?")
                     break

--- a/src/tb_watcher/pages.py
+++ b/src/tb_watcher/pages.py
@@ -105,7 +105,6 @@ class TwitterPage:
             # Dump all metadata
             extractor.write_json()
 
-
 class TwitterThread(TwitterPage):
     """
     Class encapsulating a twitter thread page.
@@ -128,7 +127,7 @@ class TwitterThread(TwitterPage):
         while state != "complete":
             time.sleep(random.uniform(3, 5))
             state = self.driver.execute_script("return document.readyState")
-    
+
         WebDriverWait(self.driver, 30).until(EC.presence_of_element_located(
             (By.CSS_SELECTOR, '[data-testid="tweet"]')))
 
@@ -152,7 +151,7 @@ class TwitterThread(TwitterPage):
 
         # Remove initial popups.
         remove_elements(self.driver, ["sheetDialog", "confirmationSheetDialog", "mask"])
-    
+
         # delete bottom element
         remove_elements(self.driver, ["BottomBar"])
 
@@ -173,25 +172,25 @@ class TwitterBio(TwitterPage):
         while state != "complete":
             time.sleep(random.uniform(3, 5))
             state = self.driver.execute_script("return document.readyState")
-    
+
         WebDriverWait(self.driver, 30).until(EC.presence_of_element_located(
             (By.CSS_SELECTOR, '[data-testid="tweet"]')))
-    
+
         # Remove initial popups.
         remove_elements(self.driver, ["sheetDialog", "confirmationSheetDialog", "mask"])
-    
+
         # delete bottom element
         remove_elements(self.driver, ["BottomBar"])
-    
+
         metadata = {}
         metadata["bio"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'div[data-testid="UserDescription"]').text)
         metadata["name"], metadata["username"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'div[data-testid="UserName"]').text.split('\n'), ("NULL", "NULL"))
         metadata["location"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'span[data-testid="UserLocation"]').text)
         metadata["website"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'a[data-testid="UserUrl"]').text)
         metadata["join_date"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'span[data-testid="UserJoinDate"]').text)
-        metadata["following"] = ensures_or(lambda: self.driver.find_element(By.XPATH, "//span[contains(text(), 'Following')]/ancestor::a/span").text) 
+        metadata["following"] = ensures_or(lambda: self.driver.find_element(By.XPATH, "//span[contains(text(), 'Following')]/ancestor::a/span").text)
         metadata["followers"] = ensures_or(lambda: self.driver.find_element(By.XPATH, "//span[contains(text(), 'Followers')]/ancestor::a/span").text)
-    
+
         if metadata.get("username", "NULL") == "NULL":
             raise RuntimeError("Fatal error, unable to resolve username {}".format(metadata))
 
@@ -209,21 +208,21 @@ class TwitterBio(TwitterPage):
         username = self.metadata.username
         assert self.metadata.username[0] == "@"
         username = username[1:]
-    
-        fpath = os.path.join(self.root_dir, username) 
+
+        fpath = os.path.join(self.root_dir, username)
         if not force and os.path.exists(fpath):
             logger.info("Folder already exists, skipping: {}".format(fpath))
             return False
         elif force and os.path.exists(fpath):
             shutil.rmtree(fpath)
-    
+
         os.makedirs(fpath)
-    
+
         # Force utf-8
         # Save a copy of the metadata
         with open(os.path.join(fpath, "metadata.json"), "w", encoding="utf-8") as f:
             json.dump(self.get_bio_as_dict(), f, ensure_ascii=False)
-    
+
         # Save a screen shot of the bio
         self.driver.save_screenshot(os.path.join(fpath, "profile.png"))
         return True

--- a/src/tb_watcher/pages.py
+++ b/src/tb_watcher/pages.py
@@ -1,0 +1,229 @@
+"""
+Logic dealing with snapshotting different pages.
+Great level of abstraction for multithreading as each
+page is independent of another page.
+
+By: ProgrammingIncluded
+"""
+# std
+import os
+import random
+import time
+import json
+import shutil
+
+from abc import abstractmethod
+from typing import Callable, List
+from dataclasses import asdict
+from urllib.parse import urlparse
+
+# tb_watcher
+from tb_watcher.logger import logger
+from tb_watcher.driver_utils import (BioMetadata, MaxCapturesReached, Scroller, TweetExtractor, Tweet,
+                                     ensures_or, remove_elements, create_chrome_driver, tweet_dom_get_basic_metadata)
+
+# selenium
+import selenium
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+class TwitterPage:
+    """Interface for a page on Twitter.
+    Each page can allow for a driveer to optimize multi-threading.
+    """
+    def __init__(self, root_dir: str, url: str, *args, auto_fetch_threads=False, existing_driver: webdriver = None, **kwargs):
+        self.metadata = None
+        self.root_dir = root_dir
+        self.auto_fetch_threads = auto_fetch_threads
+
+        if existing_driver:
+            self.driver = existing_driver
+        else:
+            self.driver = create_chrome_driver()
+        self.url = url
+
+    def get_driver(self) -> webdriver:
+        """
+        Returns the driver for a given page.
+        """
+        return self.driver
+
+    @abstractmethod
+    def fetch_metadata(self):
+        """
+        Fetches the metadata associated with the page.
+        """
+
+    def fetch_tweets(
+        self,
+        number_posts_to_cap: int,
+        load_time: int,
+        offset_func: Callable
+    ) -> List[Tweet]:
+        if self.url not in self.driver.current_url:
+            self.driver.get(self.url)
+
+        if self.metadata is None:
+            self.fetch_metadata()
+
+        save_path = os.path.join(self.root_dir, self.metadata.unique_id())
+        extractor = TweetExtractor(save_path, number_posts_to_cap)
+        # Skip the first tweet of a thread current metadata applies.
+        # Which only occurs in threads.
+        extractor.tweets_tracker.add(self.metadata)
+
+        last_id_count = 0
+        last_id = 0
+        # Wrap the offset function with extract height context.
+        try:
+            time.sleep(random.uniform(load_time, load_time + 2))
+            for _ in Scroller(self.driver, extractor.create_offset_function(offset_func), load_time):
+                if last_id_count > 5:
+                    logger.debug("No more data to load?")
+                    break
+
+                # Just in case we keep hitting the same id.
+                if last_id == extractor.counter:
+                    last_id_count += 1
+                else:
+                    last_id = extractor.counter
+                    last_id_count = 0
+
+                # Capture the tweets and generates files for them
+                extractor.capture_all_available_tweets(self.driver, self.auto_fetch_threads, load_time, offset_func)
+        except selenium.common.exceptions.StaleElementReferenceException as e:
+            logger.warning("Tweet limit reached, for {} unable to fetch more data. Authentication is required.".format(self.metadata.username))
+            logger.warning("Or you can try to bump loading times.")
+            raise e
+        except MaxCapturesReached as e:
+            pass
+        except Exception as e:
+            raise e
+        finally:
+            # Dump all metadata
+            extractor.write_json()
+
+
+class TwitterThread(TwitterPage):
+    """
+    Class encapsulating a twitter thread page.
+    Also used to resolve Tweet ID as a thread will contain
+    the Tweet's ID.
+    """
+    def __init__(self, *args, **kwargs):
+        # Force auto fetching threads to false to prevent recursion.
+        auto_fetch_threads = kwargs.get("auto_fetch_threads", False)
+        kwargs["auto_fetch_threads"] = auto_fetch_threads
+        super().__init__(*args, **kwargs)
+
+    def fetch_metadata(self) -> Tweet:
+        raw_url = self.driver.current_url
+        if self.url not in raw_url:
+            self.driver.get(self.url)
+            raw_url = self.url
+
+        state = ""
+        while state != "complete":
+            time.sleep(random.uniform(3, 5))
+            state = self.driver.execute_script("return document.readyState")
+    
+        WebDriverWait(self.driver, 30).until(EC.presence_of_element_located(
+            (By.CSS_SELECTOR, '[data-testid="tweet"]')))
+
+        # We only want the first tweet of the page which is the main tweet
+        # don't use TweetExtractor as internally it calls this function for metadata of the tweet.
+        tweets = self.driver.find_elements(By.CSS_SELECTOR, '[data-testid="tweet"]')
+        main_tweet = tweets[0]
+        dtm = tweet_dom_get_basic_metadata(main_tweet)
+
+        # Grab unique tweet id
+        assert "status/" in raw_url, "Is this a valid status URL?: {}".format(raw_url)
+        path = urlparse(raw_url).path
+        post_url =path.split("status/")[-1]
+        dtm.id = post_url.split("/")[0]
+
+        self.metadata = dtm
+
+        # Create a folder to house pictures, etc.
+        tweet_folder_fpath = os.path.join(self.root_dir, dtm.id)
+        os.makedirs(tweet_folder_fpath, exist_ok=True)
+
+        # Remove initial popups.
+        remove_elements(self.driver, ["sheetDialog", "confirmationSheetDialog", "mask"])
+    
+        # delete bottom element
+        remove_elements(self.driver, ["BottomBar"])
+
+        # Take a screenshot of the tweet.
+        main_tweet.screenshot(os.path.join(tweet_folder_fpath, "{}.png".format(dtm.id)))
+        return dtm
+
+
+class TwitterBio(TwitterPage):
+    """
+    Class encapsulating a twitter bio page.
+    """
+    def fetch_metadata(self) -> BioMetadata:
+        if self.url not in self.driver.current_url:
+            self.driver.get(self.url)
+
+        state = ""
+        while state != "complete":
+            time.sleep(random.uniform(3, 5))
+            state = self.driver.execute_script("return document.readyState")
+    
+        WebDriverWait(self.driver, 30).until(EC.presence_of_element_located(
+            (By.CSS_SELECTOR, '[data-testid="tweet"]')))
+    
+        # Remove initial popups.
+        remove_elements(self.driver, ["sheetDialog", "confirmationSheetDialog", "mask"])
+    
+        # delete bottom element
+        remove_elements(self.driver, ["BottomBar"])
+    
+        metadata = {}
+        metadata["bio"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'div[data-testid="UserDescription"]').text)
+        metadata["name"], metadata["username"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'div[data-testid="UserName"]').text.split('\n'), ("NULL", "NULL"))
+        metadata["location"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'span[data-testid="UserLocation"]').text)
+        metadata["website"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'a[data-testid="UserUrl"]').text)
+        metadata["join_date"] = ensures_or(lambda: self.driver.find_element(By.CSS_SELECTOR,'span[data-testid="UserJoinDate"]').text)
+        metadata["following"] = ensures_or(lambda: self.driver.find_element(By.XPATH, "//span[contains(text(), 'Following')]/ancestor::a/span").text) 
+        metadata["followers"] = ensures_or(lambda: self.driver.find_element(By.XPATH, "//span[contains(text(), 'Followers')]/ancestor::a/span").text)
+    
+        if metadata.get("username", "NULL") == "NULL":
+            raise RuntimeError("Fatal error, unable to resolve username {}".format(metadata))
+
+        # Save metadata as local value.
+        self.metadata = BioMetadata(**metadata)
+        return self.metadata
+
+    def get_bio_as_dict(self) -> dict:
+        return asdict(self.metadata)
+
+    def write_json(self, force=False) -> bool:
+        """
+        Returns true if wrote to file, otherwise returns false.
+        """
+        username = self.metadata.username
+        assert self.metadata.username[0] == "@"
+        username = username[1:]
+    
+        fpath = os.path.join(self.root_dir, username) 
+        if not force and os.path.exists(fpath):
+            logger.info("Folder already exists, skipping: {}".format(fpath))
+            return False
+        elif force and os.path.exists(fpath):
+            shutil.rmtree(fpath)
+    
+        os.makedirs(fpath)
+    
+        # Force utf-8
+        # Save a copy of the metadata
+        with open(os.path.join(fpath, "metadata.json"), "w", encoding="utf-8") as f:
+            json.dump(self.get_bio_as_dict(), f, ensure_ascii=False)
+    
+        # Save a screen shot of the bio
+        self.driver.save_screenshot(os.path.join(fpath, "profile.png"))
+        return True


### PR DESCRIPTION
## Changes

Another major code update to support Twitter Thread archiving. Major gist of this PR:

* Added `--depth` and `-d` for archiving threads. 
* Added `pages.py` which abstracts away a page on Twitter. Useful for multi-threading.
    * Added `TwitterPage` used for representing a page in Twitter.
    * Added `TwitterBio` which is used for fetching and obtaining bio pages.
    * Added `TwitterThread` which represents a tweet thread page.

## High Level

The high level algorithm in this PR is as follows:

1. Scroll down the page, obtain id by opening a tab to a thread specific page and extract thread id from URL.
2. For recursion purposes, snapshots are now taken in this new thread specific page.
3. Then check the depth. If there is still depth, we keep traversing each tweet until we hit no more tweets or depth is reached.
5. This process is done recursively with functions helping expand"replies" and "more replies" on each thread.

Changes in code reflect the recursive nature of the code as well as folder structure.

## Known Limitations

Due to the recursive nature of threads, once `-d >= 3`  we start to store duplicates. Without a global tracker, this would occur. We also have to decide how to store more complex DAG like data-structures which is beyond the scope of this PR.

